### PR TITLE
Install dependencies in actions

### DIFF
--- a/.github/workflows/inreach-parser.yaml
+++ b/.github/workflows/inreach-parser.yaml
@@ -48,7 +48,7 @@ jobs:
           node-version: "18"
 
       - name: Install dependiences
-        run: npm install
+        run: npm ci
         working-directory: ./inreach-parser
 
       - name: Deploy function code

--- a/.github/workflows/inreach-parser.yaml
+++ b/.github/workflows/inreach-parser.yaml
@@ -42,6 +42,15 @@ jobs:
           template: ./inreach-parser/inreach-parser.bicep
           deploymentMode: Incremental
 
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+
+      - name: Install dependiences
+        run: npm install
+        working-directory: ./inreach-parser
+
       - name: Deploy function code
         uses: azure/functions-action@v1
         if: ${{ success() && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
Funkcja się wywala, bo brakuje dependencies - dodałem krok z instalacją do Akcji, przed pushem

// CC @karol-gro 